### PR TITLE
fix type of rune and simple-rod for new SBCLs

### DIFF
--- a/characters.lisp
+++ b/characters.lisp
@@ -26,7 +26,7 @@
 
 (deftype rune () #-lispworks 'character #+lispworks 'lw:simple-char)
 (deftype rod () '(vector rune))
-(deftype simple-rod () '(simple-array rune))
+(deftype simple-rod () #-sbcl '(simple-array rune) #+sbcl '(or (simple-array rune) simple-base-string))
 
 (definline rune (rod index)
   (char rod index))


### PR DESCRIPTION
Recent-ish (a few months back) changes to SBCL's simple-base-string broke closure-common's rune types. It used to be the case that simple-base-strings were also simple-arrays (I think), but this is no longer the case, so now we make simple-rods be either simple-arrays of runes or simple-base-strings.
