### PR TITLE
comment out :type of buffer slot in xstream defstruct on ABCL

### DIFF
--- a/xstream.lisp
+++ b/xstream.lisp
@@ -109,7 +109,7 @@
   
   ;; the buffer itself
   (buffer +null-buffer+ 
-          :type (simple-array buffer-byte (*)))
+          #-abcl :type #-abcl (simple-array buffer-byte (*)))
   ;; points to the next element of `buffer' containing the next rune
   ;; about to be read.
   (read-ptr      0 :type buffer-index)


### PR DESCRIPTION
 * On ABCL, this triggers a structure redefinition error. A ticket has
   been filed on this (https://abcl.org/trac/ticket/450) but there has
   been no action on the ticket for at least 14 months. Commenting out
   the type of the slot, at least for the moment, allows
   closure-common (and cxml) to be used on current ABCLs.