### PR TITLE
fix type of rune and simple-rod for new SBCLs

### DIFF
--- a/characters.lisp
+++ b/characters.lisp
@@ -26,7 +26,7 @@
 
 (deftype rune () #-lispworks 'character #+lispworks 'lw:simple-char)
 (deftype rod () '(vector rune))
-(deftype simple-rod () '(simple-array rune))
+(deftype simple-rod () #-sbcl '(simple-array rune) #+sbcl '(or (simple-array rune) simple-base-string))
 
 (definline rune (rod index)
   (char rod index))


### PR DESCRIPTION
The type inference has gotten stronger in recent SBCLs and the simple-rods might be either (simple-array rune) or simple-base-string. Accept either on SBCL.