### PR TITLE
fix definition of simple-rod type

### DIFF
--- a/characters.lisp
+++ b/characters.lisp
@@ -26,7 +26,7 @@
 
 (deftype rune () #-lispworks 'character #+lispworks 'lw:simple-char)
 (deftype rod () '(vector rune))
-(deftype simple-rod () '(simple-array rune))
+(deftype simple-rod () '(simple-array rune (*)))
 
 (definline rune (rod index)
   (char rod index))


### PR DESCRIPTION
 * As pointed out by David Lichteblau, the definition of simple-rod
   was wrong. simple-rod shouldn't just be a simple-array of runes, it
   should be a 1-d simple-array of runes.