### PR TITLE
Assorted changes.

### DIFF
--- a/characters.lisp
+++ b/characters.lisp
@@ -81,7 +81,8 @@
 
 (defun rod (x)
   (cond
-    ((stringp x)    x)
+    ((typep x 'rod) x)
+    ((stringp x)    (coerce x 'rod))
     ((symbolp x)    (string x))
     ((characterp x) (string x))
     ((vectorp x)    (coerce x 'string))

--- a/encodings.lisp
+++ b/encodings.lisp
@@ -75,10 +75,11 @@
      ',name))
 
 (defun find-encoding (name)
-  (let ((x (gethash (resolve-name name) *encodings*)))
-    (and x
-         (or (first x)
-             (setf (first x) (funcall (second x)))))))
+  (if (string-equal name "us-ascii") :utf-8
+      (let ((x (gethash (resolve-name name) *encodings*)))
+        (and x
+             (or (first x)
+                 (setf (first x) (funcall (second x))))))))
 
 (defclass encoding () ())
 

--- a/syntax.lisp
+++ b/syntax.lisp
@@ -145,7 +145,7 @@
        (error "Meaningless rune name ~S." name)))))
 
 (defun rune-reader (stream subchar arg)
-  subchar arg
+  (declare (ignore subchar arg))
   (values (rune-from-read-name (read-rune-name stream))))
 
 (set-dispatch-macro-character #\# #\/ 'rune-reader)

--- a/xstream.lisp
+++ b/xstream.lisp
@@ -397,16 +397,6 @@
    #-CLISP read-sequence
            sequence stream :start start :end end))
 
-#+cmu
-(defmethod read-octets :around (sequence (stream stream) start end)
-  ;; CMUCL <= 19a on non-SunOS accidentally triggers EFAULT in read(2)
-  ;; if SEQUENCE has been write protected by GC.  Workaround: Touch all pages
-  ;; in SEQUENCE and make sure no GC happens between that and the read(2).
-  (ext::without-gcing
-   (loop for i from start below end
-         do (setf (elt sequence i) (elt sequence i)))
-   (call-next-method)))
-
 (defmethod read-octets (sequence (stream null) start end)
   (declare (ignore sequence start end))
   0)


### PR DESCRIPTION
Handle the US-ASCII encoding; fix a bug due to SBCL's string types; supply a missing declaration; drop a workaround for an ancient version of CMUCL.